### PR TITLE
Laden beim schließen in Kunden behoben

### DIFF
--- a/Blob/src/app/customer/cutomer-dashboard/cutomer-dashboard.component.ts
+++ b/Blob/src/app/customer/cutomer-dashboard/cutomer-dashboard.component.ts
@@ -163,6 +163,7 @@ export class CutomerDashboardComponent implements OnInit {
 
   handlePopupCancel(): void {
     this.isPopupVisible = false;
+    this.isLoading = false;
   }
 
   submitAddForm(): void {


### PR DESCRIPTION
Beim schließen des Dialogs im Kunden Dashboard wird das loading jetzt deaktiviert